### PR TITLE
Class load error is fixed

### DIFF
--- a/wifidb/tools/test_scripts/Test_ExportAll.php
+++ b/wifidb/tools/test_scripts/Test_ExportAll.php
@@ -12,6 +12,6 @@ $dbcore->verbosed("Testing KML Update KML file.");
 
 echo "Start\r\n";
 $dbcore->named = 0;
-var_dump($dbcore->ExportAllkml());
+var_dump($dbcore->export->ExportAllkml());
 
 echo "End\r\n";

--- a/wifidb/tools/test_scripts/Test_ExportDailykml.php
+++ b/wifidb/tools/test_scripts/Test_ExportDailykml.php
@@ -8,4 +8,4 @@ require( '../config.inc.php' );
 require( $daemon_config['wifidb_install']."/lib/init.inc.php" );
 
 $dbcore->named = 0;
-var_dump($dbcore->ExportDailykml("2013-07-18"));
+var_dump($dbcore->export->ExportDailykml("2013-07-18"));

--- a/wifidb/tools/test_scripts/Test_ExportSingleAP.php
+++ b/wifidb/tools/test_scripts/Test_ExportSingleAP.php
@@ -7,4 +7,4 @@ define("SWITCH_EXTRAS", "export");
 require( '../config.inc.php' );
 require( $daemon_config['wifidb_install']."/lib/init.inc.php" );
 
-var_dump($dbcore->ExportSingleAP(1));
+var_dump($dbcore->export->ExportSingleAP(1));

--- a/wifidb/wifidb/lib/init.inc.php
+++ b/wifidb/wifidb/lib/init.inc.php
@@ -112,6 +112,7 @@ function __autoload($class)
         return 1;
     }else
     {
+
         throw new errorexception("Could not load class `{$class}`");
     }
 }
@@ -169,6 +170,9 @@ try
                 break;
 
                 case "export":
+                    __autoload("createKML");
+                    __autoload("convert");
+                    __autoload("export");
                     $dbcore = new frontend($config);
                     $dbcore->createKML = new createKML($dbcore, $config);
                     $dbcore->convert = new convert($config);

--- a/wifidb/wifidb/lib/init.inc.php
+++ b/wifidb/wifidb/lib/init.inc.php
@@ -177,7 +177,6 @@ try
 
                 case "graph":
                     $dbcore = new frontend($config);
-                    __autoload('graphs');
                     $dbcore->graphs = new graphs($dbcore->PATH, $dbcore->URL_PATH);
                 break;
 				
@@ -193,10 +192,10 @@ try
             break;
         ################
         Default:
-            die("Unknown Switch Set.");
+            die("Unknown Switch Set. gurgle...cough...dead...");
             break;
     }
-    #done setting up WiFiDB, weather it be the daemon or the web interface, or just plain failing.
+    #done setting up WiFiDB, whether it be the daemon or the web interface, or just plain failing in a spectacular fashion...
 }
 catch (Exception $e) {
     throw new ErrorException($e);


### PR DESCRIPTION
For some reason on the frontend (HTML) part of the init script i need to use the __autoload function. But the CLI part does not need this.. WTF?!
